### PR TITLE
GHSA-9c47-m6qq-7p4h - The vulnerability affects only dev dependencies…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,19 @@
 version: 2.1
+orbs:
+  node: circleci/node@5.0.3
+
 jobs:
   build:
     docker:
-      - image: cimg/node:12.3.0
+      - image: 'cimg/base:stable'
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - node/install:
+          node-version: '12.3.0'
+      - node/install-packages:
+          cache-path: ~/project/node_modules
       - run:
-          name: Installing Dependencies
-          command: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-      - run:
-          name: "Running audit"
+          name: Running audit
           command: npm run audit
       - run:
           name: Running Mocha Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 'cimg/base:stable'
+      - image: cimg/base:stable
     steps:
       - checkout
       - node/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   node: circleci/node@5.0.3
-
 jobs:
   build:
     docker:
@@ -9,9 +8,10 @@ jobs:
     steps:
       - checkout
       - node/install:
-          node-version: '12.3.0'
+          node-version: '14.19.3'
       - node/install-packages:
           cache-path: ~/project/node_modules
+          override-ci-command: npm install
       - run:
           name: Running audit
           command: npm run audit

--- a/.nsprc
+++ b/.nsprc
@@ -6,5 +6,9 @@
     "GHSA-27h2-hvpr-p74q": {
         "active": true,
         "notes": "The vulnerability is in maester-client v4.x because of cross-dependency with component-commons-library. Maester-client of v4.x doesn't use jwt.verify function. So not affected"
+    },
+    "GHSA-9c47-m6qq-7p4h": {
+        "active": true,
+        "notes": "The vulnerability affects only dev dependencies: eslint-plugin-import and nyc. Packages are not fixed yet"
     }
 }

--- a/.nsprc
+++ b/.nsprc
@@ -6,9 +6,5 @@
     "GHSA-27h2-hvpr-p74q": {
         "active": true,
         "notes": "The vulnerability is in maester-client v4.x because of cross-dependency with component-commons-library. Maester-client of v4.x doesn't use jwt.verify function. So not affected"
-    },
-    "GHSA-9c47-m6qq-7p4h": {
-        "active": true,
-        "notes": "The vulnerability affects only dev dependencies: eslint-plugin-import and nyc. Packages are not fixed yet"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic.io/maester-client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
…: eslint-plugin-import and nyc. Packages are not fixed yet